### PR TITLE
Add single-file React tennis scheduler app

### DIFF
--- a/tennis
+++ b/tennis
@@ -1,1 +1,549 @@
+import React, { useMemo, useState, useEffect } from "react";
+
+/**
+ * 신나용테니스 대진표 앱 (단일 파일 React)
+ * v6 — 요청 반영: 하드 퇴장금지, 수동 편집(드래그&드롭), 토스 감성 UI, PWA 가이드, 추가 테스트
+ *
+ * ✅ 추가/변경 사항
+ * - [옵션] 하드 제약: "퇴장 이후 절대 배정 금지" 토글 → 스케줄러에서 슬롯 시작시간 >= leaveBy 인 선수는 제외
+ * - [수동 편집] 드래그&드롭으로 슬롯 내 플레이어 교체/스왑 (간단 유효성 검사: 성별 규칙, 중복 금지, 하드 퇴장금지)
+ * - [디자인] 밝은 여백, 카드 보더, 파랑 액션(토스 느히기)
+ * - [CSV] 현재 화면의 스케줄(자동/수동 반영)으로 내보내기
+ * - [테스트] 하드 퇴장금지/성별 규칙 검증 케이스 추가
+ *
+ * 📦 PWA & 템플릿 가이드 (파일로 분리 필요)
+ * - manifest.webmanifest
+ *   {
+ *     "name": "신나용테니스 대진표",
+ *     "short_name": "신나용",
+ *     "start_url": "/",
+ *     "display": "standalone",
+ *     "background_color": "#FFFFFF",
+ *     "theme_color": "#1A73E8",
+ *     "icons": [{"src":"/icon-192.png","sizes":"192x192","type":"image/png"},{"src":"/icon-512.png","sizes":"512x512","type":"image/png"}]
+ *   }
+ * - sw.js (아주 단순 캐시)
+ *   self.addEventListener('install', e=>self.skipWaiting());
+ *   self.addEventListener('activate', e=>self.clients.claim());
+ *   self.addEventListener('fetch', ()=>{});
+ * - React/Vite에서: index.html에 <link rel="manifest" href="/manifest.webmanifest"> 추가하고, main.tsx에서 navigator.serviceWorker.register('/sw.js')
+ * - Next.js(App Router): app/manifest.webmanifest 파일 추가, public/sw.js 넣고 layout.tsx에서 <link rel="manifest"/> 및 SW 등록
+ */
+
+const GENDERS = { M: "남", F: "여" };
+const MATCH_TYPES = ["남복", "여복", "혼복", "잡복"]; // 잡복=성별 무관 복식
+
+const DEFAULT_PLAYERS = [
+  { name: "세준", gender: "M", rating: 3.5 },
+  { name: "도현", gender: "M", rating: 3.5 },
+  { name: "낥현", gender: "M", rating: 3.0 },
+  { name: "정택", gender: "M", rating: 3.0 },
+  { name: "익규", gender: "M", rating: 3.0 },
+  { name: "길홍", gender: "M", rating: 3.5 },
+  { name: "상용", gender: "M", rating: 3.0 },
+  { name: "형석", gender: "M", rating: 3.0 },
+  { name: "승현", gender: "M", rating: 3.0 },
+  { name: "수현", gender: "F", rating: 3.0 },
+  { name: "혜림", gender: "F", rating: 3.0 },
+  { name: "지현", gender: "F", rating: 3.0 },
+  { name: "다혜", gender: "F", rating: 3.0 },
+  { name: "해은", gender: "F", rating: 2.5 },
+  { name: "민경", gender: "F", rating: 3.0 },
+  { name: "서울", gender: "F", rating: 3.0 },
+];
+
+// ---------- 유틸 ----------
+function shuffle(arr, seed = 1) {
+  let a = 1664525, c = 1013904223; const m = 2 ** 32; let s = seed >>> 0;
+  const r = [...arr];
+  for (let i = r.length - 1; i > 0; i--) { s = (a * s + c) % m; const j = s % (i + 1); [r[i], r[j]] = [r[j], r[i]]; }
+  return r;
+}
+
+function toTimeStr(date) { const hh = String(date.getHours()).padStart(2, "0"); const mm = String(date.getMinutes()).padStart(2, "0"); return `${hh}:${mm}`; }
+function addMinutes(date, mins) { const d = new Date(date.getTime()); d.setMinutes(d.getMinutes() + mins); return d; }
+function timeStrToMinutes(hhmm) { if (!hhmm) return null; const [h, m] = hhmm.split(":").map(Number); if (Number.isNaN(h) || Number.isNaN(m)) return null; return h * 60 + m; }
+function pairKey(p1, p2) { const [a, b] = [p1, p2].sort(); return `${a}__${b}`; }
+
+const arrayEquals = (A,B)=>A.length===B.length&&A.every((v,i)=>v===B[i]);
+
+// ---------- 페어 생성 (타입별) ----------
+function makePairs(players, type) {
+  const males = players.filter((p) => p.gender === "M");
+  const females = players.filter((p) => p.gender === "F");
+  const all = players;
+  const byName = Object.fromEntries(players.map((p) => [p.name, p]));
+
+  const pairs = [];
+  const add = (a, b) => {
+    if (a.name === b.name) return;
+    const ra = byName[a.name]?.rating ?? 3.0;
+    const rb = byName[b.name]?.rating ?? 3.0;
+    pairs.push({ a: a.name, b: b.name, key: pairKey(a.name, b.name), ra, rb, ratingSum: ra + rb });
+  };
+  if (type === "남복") {
+    for (let i = 0; i < males.length; i++) for (let j = i + 1; j < males.length; j++) add(males[i], males[j]);
+  } else if (type === "여복") {
+    for (let i = 0; i < females.length; i++) for (let j = i + 1; j < females.length; j++) add(females[i], females[j]);
+  } else if (type === "혼복") {
+    for (const m of males) for (const f of females) add(m, f);
+  } else { // 잡복
+    for (let i = 0; i < all.length; i++) for (let j = i + 1; j < all.length; j++) add(all[i], all[j]);
+  }
+  return pairs;
+}
+
+function isPairValidForType(type, nameA, nameB, playersMap) {
+  const ga = playersMap.get(nameA)?.gender; const gb = playersMap.get(nameB)?.gender;
+  if (!ga || !gb) return false;
+  if (type === "남복") return ga === "M" && gb === "M";
+  if (type === "여복") return ga === "F" && gb === "F";
+  if (type === "혼복") return (ga === "M" && gb === "F") || (ga === "F" && gb === "M");
+  return true; // 잡복
+}
+
+// ---------- 스케줄러 ----------
+function scheduleMatches({ players, slots, seed, maxGamesPerPlayer, hardLeaveBan }) {
+  const gamesPerPlayer = Object.fromEntries(players.map((p) => [p.name, 0]));
+  const pairUsed = {}; // pairKey -> count
+  const schedule = slots.map((s) => ({ ...s, teamA: null, teamB: null }));
+
+  // 같은 시간대 묶기
+  const byTime = {}; for (const s of schedule) { (byTime[s.timeStr] ||= []).push(s); }
+  const timeKeys = Object.keys(byTime).sort();
+
+  // 퇴장 시간(leaveBy) 우선/제외용
+  const leaveMin = Object.fromEntries(players.map((p) => [p.name, timeStrToMinutes(p.leaveBy)]));
+  const isBannedByLeave = (name, slotMin) => {
+    const lm = leaveMin[name];
+    if (lm == null) return false;
+    // 슬롯 시작시간이 퇴장시간 이상이면 배정 금지
+    return slotMin >= lm;
+  };
+
+  const pairBaseScore = (pair) => {
+    const used = (pairUsed[pair.key] || 0) * 5; // 페어 중복 가중치
+    const load = (gamesPerPlayer[pair.a] || 0) + (gamesPerPlayer[pair.b] || 0); // 개인 출전 로드
+    return used + load;
+  };
+
+  const urgencyScore = (pair, slotMin) => {
+    const diffs = [leaveMin[pair.a], leaveMin[pair.b]].filter((v) => v != null).map((v) => v - slotMin);
+    if (diffs.length === 0) return 9999; // 퇴장 시간 없음
+    const minDiff = Math.min(...diffs); if (minDiff < 0) return 10000; // 이미 지나은 경우 패널티
+    return minDiff; // 분 단위
+  };
+
+  const playersMap = new Map(players.map(p=>[p.name,p]));
+
+  for (const t of timeKeys) {
+    const timeSlots = byTime[t];
+    const usedPlayers = new Set();
+    const slotMin = timeStrToMinutes(t) ?? 0;
+
+    for (const slot of timeSlots) {
+      const candidatesRaw = makePairs(players, slot.type);
+      const candidates = shuffle(candidatesRaw, seed + slot.slotIndex)
+        .filter((p) => !usedPlayers.has(p.a) && !usedPlayers.has(p.b))
+        .filter((p) => isPairValidForType(slot.type, p.a, p.b, playersMap))
+        .filter((p) => !maxGamesPerPlayer || (gamesPerPlayer[p.a] < maxGamesPerPlayer && gamesPerPlayer[p.b] < maxGamesPerPlayer))
+        .filter((p) => !hardLeaveBan || (!isBannedByLeave(p.a, slotMin) && !isBannedByLeave(p.b, slotMin)))
+        .sort((a, b) => (pairBaseScore(a) + urgencyScore(a, slotMin) * 0.1) - (pairBaseScore(b) + urgencyScore(b, slotMin) * 0.1));
+
+      const teamA = candidates[0]; if (!teamA) continue;
+      const teamB = candidates
+        .slice(1)
+        .filter((p) => p.a !== teamA.a && p.a !== teamA.b && p.b !== teamA.a && p.b !== teamA.b)
+        .filter((p) => !usedPlayers.has(p.a) && !usedPlayers.has(p.b))
+        .filter((p) => !maxGamesPerPlayer || (gamesPerPlayer[p.a] < maxGamesPerPlayer && gamesPerPlayer[p.b] < maxGamesPerPlayer))
+        .filter((p) => !hardLeaveBan || (!isBannedByLeave(p.a, slotMin) && !isBannedByLeave(p.b, slotMin)))
+        .sort((a, b) => {
+          const ad = Math.abs(teamA.ratingSum - a.ratingSum);
+          const bd = Math.abs(teamA.ratingSum - b.ratingSum);
+          const aScore = ad * 2 + pairBaseScore(a) + urgencyScore(a, slotMin) * 0.1;
+          const bScore = bd * 2 + pairBaseScore(b) + urgencyScore(b, slotMin) * 0.1;
+          return aScore - bScore;
+        })[0];
+
+      if (!teamB) continue;
+
+      slot.teamA = teamA; slot.teamB = teamB;
+      usedPlayers.add(teamA.a); usedPlayers.add(teamA.b); usedPlayers.add(teamB.a); usedPlayers.add(teamB.b);
+      gamesPerPlayer[teamA.a]++; gamesPerPlayer[teamA.b]++; gamesPerPlayer[teamB.a]++; gamesPerPlayer[teamB.b]++;
+      pairUsed[teamA.key] = (pairUsed[teamA.key] || 0) + 1; pairUsed[teamB.key] = (pairUsed[teamB.key] || 0) + 1;
+    }
+  }
+
+  return { schedule, gamesPerPlayer, pairUsed };
+}
+
+// ---------- 슬롯 생성 ----------
+function makeDefaultSlots({ startTime = "08:00", endTime = "10:00", intervalMin = 30, courts = 2, pattern = ["남복", "혼복", "남복", "혼복"] }) {
+  const [sh, sm] = startTime.split(":").map(Number); const [eh, em] = endTime.split(":").map(Number);
+  const start = new Date(2020, 0, 1, sh, sm, 0); const end = new Date(2020, 0, 1, eh, em, 0);
+  const times = []; let cur = start; while (cur < end) { times.push(toTimeStr(cur)); cur = addMinutes(cur, intervalMin); }
+  const slots = []; times.forEach((timeStr, idx) => { for (let c = 1; c <= courts; c++) { const type = pattern[idx % pattern.length]; slots.push({ slotIndex: slots.length, timeStr, courtIndex: c, type }); } });
+  return slots;
+}
+
+// ---------- 요약 계산 ----------
+function summarize(schedule) {
+  const gamesPerPlayer = {};
+  const pairUsed = {};
+  for (const s of schedule) {
+    for (const team of [s.teamA, s.teamB]) {
+      if (!team) continue;
+      for (const n of [team.a, team.b]) {
+        gamesPerPlayer[n] = (gamesPerPlayer[n] || 0) + 1;
+      }
+      pairUsed[team.key] = (pairUsed[team.key] || 0) + 1;
+    }
+  }
+  return { gamesPerPlayer, pairUsed };
+}
+
+// ---------- CSV ----------
+function csvExport(schedule) {
+  const header = ["게임","\uce74트","\uc77c정","\uacbd\uae30\ud0c0\uc785","\ud300A1","\ud300A2","\ud300B1","\ud300B2"].join(",");
+  const rows = schedule.map((s, i) => {
+    const a1 = s.teamA ? s.teamA.a : "-"; const a2 = s.teamA ? s.teamA.b : "-";
+    const b1 = s.teamB ? s.teamB.a : "-"; const b2 = s.teamB ? s.teamB.b : "-";
+    return [i + 1, s.courtIndex, s.timeStr, s.type, a1, a2, b1, b2].join(",");
+  });
+  const csv = [header, ...rows].join("\n");
+  const blob = new Blob(["\ufeff" + csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob); const a = document.createElement("a");
+  a.href = url; a.download = `shin-nayong-schedule.csv`; a.click(); URL.revokeObjectURL(url);
+}
+
+// ---------- 테스트 ----------
+function runTests() {
+  // 1) CSV 줄바꿈 문자열
+  const t1 = ["a", "b"].join("\n"); console.assert(t1.includes("\n"), "CSV join should include newline");
+
+  // 2) 기본 매칭 테스트 (혼복, 1코트, 한 타임)
+  const p = [
+    { name: "M1", gender: "M", rating: 3.0 },
+    { name: "F1", gender: "F", rating: 3.0 },
+    { name: "M2", gender: "M", rating: 3.0 },
+    { name: "F2", gender: "F", rating: 3.0 },
+  ];
+  const oneSlot = [{ slotIndex: 0, timeStr: "08:00", courtIndex: 1, type: "\ud63c\ubcf5" }];
+  const { schedule } = scheduleMatches({ players: p, slots: oneSlot, seed: 1, maxGamesPerPlayer: 0, hardLeaveBan: false });
+  console.assert(schedule[0].teamA && schedule[0].teamB, "Two pairs should be scheduled for a doubles court");
+  const { teamA, teamB } = schedule[0];
+  const noOverlap = new Set([teamA.a, teamA.b, teamB.a, teamB.b]).size === 4; console.assert(noOverlap, "Players must be unique per court/time");
+
+  // 3) 성별 규칙 테스트
+  const map = new Map(p.map(x=>[x.name,x]));
+  console.assert(isPairValidForType("\ub0a8\ubcf5","M1","M2",map) === true, "\ub0a8\ubcf5 \uaddc\uce59 \uc2e4\ud328");
+  console.assert(isPairValidForType("\uc5ec\ubcf5","F1","F2",map) === true, "\uc5ec\ubcf5 \uaddc\uce59 \uc2e4\ud328");
+  console.assert(isPairValidForType("\ud63c\ubcf5","M1","F1",map) === true, "\ud63c\ubcf5 \uaddc\uce59 \uc2e4\ud328");
+  console.assert(isPairValidForType("\ud63c\ubcf5","M1","M2",map) === false, "\ud63c\ubcf5 \uc798\ubabb \ud5c8용");
+
+  // 4) 하드 퇴장금지 테스트
+  const p2 = [
+    { name: "A", gender: "M", rating: 3.0, leaveBy: "08:30" },
+    { name: "B", gender: "M", rating: 3.0 },
+    { name: "C", gender: "F", rating: 3.0 },
+    { name: "D", gender: "F", rating: 3.0 },
+    { name: "E", gender: "M", rating: 3.0 },
+    { name: "F", gender: "F", rating: 3.0 },
+  ];
+  const slot2 = [ { slotIndex: 0, timeStr: "08:30", courtIndex: 1, type: "\ud63c\ubcf5" } ];
+  const { schedule: s2 } = scheduleMatches({ players: p2, slots: slot2, seed: 1, maxGamesPerPlayer: 0, hardLeaveBan: true });
+  const names2 = s2[0] && s2[0].teamA ? [s2[0].teamA.a, s2[0].teamA.b, s2[0].teamB?.a, s2[0].teamB?.b].filter(Boolean) : [];
+  console.assert(!names2.includes("A"), "\ud1f4장 이후 절대 배정 금지 \uc2e4\ud328");
+}
+
+// ---------- 메인 컴포넌트 ----------
+export default function App() {
+  const [players, setPlayers] = useState(DEFAULT_PLAYERS.map((p) => ({ ...p, rating: p.rating ?? 3.0, leaveBy: p.leaveBy ?? "" })));
+  const [seed, setSeed] = useState(42);
+  const [startTime, setStartTime] = useState("08:00");
+  const [endTime, setEndTime] = useState("10:00");
+  const [intervalMin, setIntervalMin] = useState(30);
+  const [courts, setCourts] = useState(2);
+  const [patternText, setPatternText] = useState("\ub0a8\ubcf5,\ud63c\ubcf5,\ub0a8\ubcf5,\ud63c\ubcf5");
+  const [maxGamesPerPlayer, setMaxGamesPerPlayer] = useState(0); // 0=\ubb34제한
+  const [hardLeaveBan, setHardLeaveBan] = useState(true);
+  const [editMode, setEditMode] = useState(false);
+  const [manualSchedule, setManualSchedule] = useState(null);
+
+  useEffect(() => { try { runTests(); console.log("\u2705 Basic tests passed"); } catch (e) { console.error("\u274c Test failed:", e); } }, []);
+
+  const pattern = useMemo(() => patternText.split(",").map((s) => s.trim()).filter((s) => MATCH_TYPES.includes(s)), [patternText]);
+  const slots = useMemo(() => makeDefaultSlots({ startTime, endTime, intervalMin, courts, pattern: pattern.length ? pattern : ["\uc7a1\ubcf5"] }), [startTime, endTime, intervalMin, courts, pattern]);
+
+  const generated = useMemo(() => scheduleMatches({ players, slots, seed, maxGamesPerPlayer, hardLeaveBan }), [players, slots, seed, maxGamesPerPlayer, hardLeaveBan]);
+
+  // 수동편집 토글 시 현재 자동 스케줄을 복제
+  useEffect(() => { if (editMode && !manualSchedule) setManualSchedule(JSON.parse(JSON.stringify(generated.schedule))); }, [editMode]);
+  // 자동 스케줄이 바뀌면, 수동모드 아님 때 표시도 갱신
+  useEffect(() => { if (!editMode) setManualSchedule(null); }, [generated.schedule, editMode]);
+
+  const displaySchedule = editMode ? (manualSchedule || []) : generated.schedule;
+  const { gamesPerPlayer, pairUsed } = editMode ? summarize(displaySchedule) : { gamesPerPlayer: generated.gamesPerPlayer, pairUsed: generated.pairUsed };
+
+  const playersMap = useMemo(() => new Map(players.map(p=>[p.name,p])), [players]);
+  const getRating = (name)=> playersMap.get(name)?.rating ?? 3.0;
+
+  // ---- Drag&Drop helpers ----
+  const onDragStart = (e, payload) => { e.dataTransfer.setData('application/json', JSON.stringify(payload)); e.dataTransfer.effectAllowed = 'move'; };
+  const onDragOver = (e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; };
+
+  const replaceOrSwap = (target, source) => {
+    // target: {slotIdx, teamKey:'teamA'|'teamB', placeKey:'a'|'b'}
+    // source: {type:'bench'|'slot', name, slotIdx?, teamKey?, placeKey?}
+    setManualSchedule(prev => {
+      const next = JSON.parse(JSON.stringify(prev));
+      const slot = next[target.slotIdx]; if (!slot) return prev;
+      const slotMin = timeStrToMinutes(slot.timeStr) ?? 0;
+
+      const currName = slot[target.teamKey]?.[target.placeKey];
+      const newName = source.name;
+
+      // 중복: 동일 시간대 같은 이름 2회 금지
+      const sameTime = next.filter(s=>s.timeStr===slot.timeStr);
+      const existsInTime = sameTime.some(s=>{
+        for (const t of [s.teamA, s.teamB]) if (t && (t.a===newName || t.b===newName)) return true; return false;
+      });
+      if (existsInTime && !(source.type==='slot' && source.slotIdx===target.slotIdx)) { alert('\uac19\uc740 \uc2dc\uac04\ub300\uc5d0 \uc911\ubcf5 \ubc30\uc815\uc740 \ubd88\uac00\ud569\ub2c8\ub2e4.'); return prev; }
+
+      // 하드 퇴장 금지
+      if (hardLeaveBan) {
+        const lm = playersMap.get(newName)?.leaveBy; const lmMin = timeStrToMinutes(lm);
+        if (lmMin!=null && slotMin >= lmMin) { alert('\ud1f4\uc7a5 \uc774\ud6c4 \uc2dc\uac04\uc5d0\ub294 \ubc30\uc815\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.'); return prev; }
+      }
+
+      // 성별 규칙
+      const team = slot[target.teamKey] || { a: '', b: '', ra: 0, rb: 0, ratingSum: 0 };
+      const aName = target.placeKey==='a' ? newName : team.a || currName; // 예상 배치 후 이름들
+      const bName = target.placeKey==='b' ? newName : team.b || currName;
+      if (aName && bName) {
+        if (!isPairValidForType(slot.type, aName, bName, playersMap)) { alert('\ud574\ub2f9 \uacbd\uae30 \ud0c0\uc785\uc758 \uc131\ubcc4 \uaddc\uce59\uc5d0 \ub9de지 \uc54a\uc2b5\ub2c8\ub2e4.'); return prev; }
+      }
+
+      // 적용
+      const newTeam = { ...team };
+      if (target.placeKey==='a') { newTeam.a = newName; newTeam.ra = getRating(newName); }
+      else { newTeam.b = newName; newTeam.rb = getRating(newName); }
+      newTeam.ra = newTeam.ra ?? getRating(newTeam.a);
+      newTeam.rb = newTeam.rb ?? getRating(newTeam.b);
+      newTeam.key = pairKey(newTeam.a, newTeam.b);
+      newTeam.ratingSum = (newTeam.ra||0) + (newTeam.rb||0);
+      slot[target.teamKey] = newTeam;
+
+      // 스왑: source가 슬롯이면 그 자리에 currName 넣기
+      if (source.type==='slot') {
+        const src = next[source.slotIdx]; if (src) {
+          const srcTeam = { ...(src[source.teamKey] || {}) };
+          if (source.placeKey==='a') { srcTeam.a = currName; srcTeam.ra = getRating(currName); }
+          else { srcTeam.b = currName; srcTeam.rb = getRating(currName); }
+          srcTeam.ra = srcTeam.ra ?? getRating(srcTeam.a);
+          srcTeam.rb = srcTeam.rb ?? getRating(srcTeam.b);
+          srcTeam.key = pairKey(srcTeam.a, srcTeam.b);
+          srcTeam.ratingSum = (srcTeam.ra||0) + (srcTeam.rb||0);
+          src[source.teamKey] = srcTeam;
+        }
+      }
+      return next;
+    });
+  };
+
+  const makeDropHandlers = (slotIdx, teamKey, placeKey) => ({
+    onDragOver,
+    onDrop: (e) => {
+      e.preventDefault();
+      if (!editMode) return;
+      const data = e.dataTransfer.getData('application/json'); if (!data) return;
+      const payload = JSON.parse(data);
+      replaceOrSwap({ slotIdx, teamKey, placeKey }, payload);
+    }
+  });
+
+  const addPlayer = () => {
+    const name = prompt("\uc774\ub984?"); if (!name) return;
+    const gender = prompt("\uc131\ubcc4? (M/F)", "M"); if (!gender || !["M", "F"].includes(gender.toUpperCase())) return;
+    const rating = parseFloat(prompt("NTRP (1.0~5.0, 0.5 \ub2e8\uc704)", "3.0") || "3.0");
+    setPlayers((ps) => [...ps, { name, gender: gender.toUpperCase(), rating: Number.isNaN(rating) ? 3.0 : rating, leaveBy: "" }]);
+  };
+  const removePlayer = (name) => setPlayers((ps) => ps.filter((p) => p.name !== name));
+  const toggleGender = (name) => setPlayers((ps) => ps.map((p) => (p.name === name ? { ...p, gender: p.gender === "M" ? "F" : "M" } : p)));
+  const regenerate = () => setSeed((s) => s + 1);
+  const updatePlayer = (name, patch) => setPlayers((ps) => ps.map((p) => (p.name === name ? { ...p, ...patch } : p)));
+
+  const exportCurrent = () => csvExport(displaySchedule);
+
+  // ---- UI helpers ----
+  const PlayerChip = ({ name, small=false }) => (
+    <span draggable={editMode}
+      onDragStart={(e)=>onDragStart(e,{ type:'bench', name })}
+      className={`inline-flex items-center gap-1 ${small? 'px-1.5 py-0.5 text-xs':'px-2 py-1 text-sm'} rounded-full border bg-white hover:bg-slate-50 cursor-${editMode?'grab':'default'} select-none`}
+    >
+      <span className="font-medium">{name}</span>
+      <span className="text-[11px] text-slate-500">{getRating(name).toFixed(1)}</span>
+    </span>
+  );
+
+  const DropSlot = ({ slotIdx, teamKey, placeKey, name }) => (
+    <div {...makeDropHandlers(slotIdx, teamKey, placeKey)} className="inline-flex items-center gap-1 px-2 py-1 rounded-lg border bg-white min-w-[120px]">
+      {name ? (
+        <span draggable={editMode}
+              onDragStart={(e)=>onDragStart(e,{ type:'slot', name, slotIdx, teamKey, placeKey })}
+              className="cursor-grab">
+          <PlayerChip name={name} small/>
+        </span>
+      ) : (
+        <span className="text-xs text-slate-400">여기에 드롯</span>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen w-full bg-gradient-to-b from-slate-50 to-white text-slate-900">
+      <div className="max-w-6xl mx-auto p-6 space-y-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold tracking-tight">신나용테니스 대진표 생성기</h1>
+          <div className="flex items-center gap-2">
+            <button onClick={regenerate} className="px-3 py-2 rounded-xl bg-white border shadow-sm hover:shadow-md">재생성</button>
+            <button onClick={exportCurrent} className="px-3 py-2 rounded-xl bg-white border shadow-sm hover:shadow-md">CSV 내보내기</button>
+          </div>
+        </header>
+
+        {/* 설정 카드 */}
+        <section className="grid lg:grid-cols-3 gap-4">
+          <div className="bg-white rounded-2xl border border-slate-200 p-4 space-y-3">
+            <h2 className="font-semibold">시간/\ucf54트 \uc124정</h2>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="text-sm">시작시간
+                <input value={startTime} onChange={(e) => setStartTime(e.target.value)} type="time" className="w-full mt-1 border rounded-lg px-2 py-1" />
+              </label>
+              <label className="text-sm">종료시간
+                <input value={endTime} onChange={(e) => setEndTime(e.target.value)} type="time" className="w-full mt-1 border rounded-lg px-2 py-1" />
+              </label>
+              <label className="text-sm">인터볼(분)
+                <input value={intervalMin} onChange={(e) => setIntervalMin(+e.target.value)} type="number" min={10} step={5} className="w-full mt-1 border rounded-lg px-2 py-1" />
+              </label>
+              <label className="text-sm">코트 수
+                <input value={courts} onChange={(e) => setCourts(+e.target.value)} type="number" min={1} max={6} className="w-full mt-1 border rounded-lg px-2 py-1" />
+              </label>
+            </div>
+            <label className="text-sm block">타입 \ud328턴 (쉐멀 구분)
+              <input value={patternText} onChange={(e) => setPatternText(e.target.value)} placeholder="예: 남복,혼복,남복,혼복" className="w-full mt-1 border rounded-lg px-2 py-1" />
+            </label>
+            <label className="text-sm block">선수 1인당 최대 경기수 (0=\ubb34제한)
+              <input value={maxGamesPerPlayer} onChange={(e) => setMaxGamesPerPlayer(+e.target.value)} type="number" min={0} className="w-full mt-1 border rounded-lg px-2 py-1" />
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={hardLeaveBan} onChange={(e)=>setHardLeaveBan(e.target.checked)} />
+              퇴장 이후 <b>절대</b> \ubc30정 금지
+            </label>
+          </div>
+
+          <div className="bg-white rounded-2xl border border-slate-200 p-4 space-y-3 lg:col-span-2">
+            <div className="flex items-center justify-between">
+              <h2 className="font-semibold">선수 명단</h2>
+              <div className="flex items-center gap-2">
+                <button onClick={()=>setEditMode(m=>!m)} className={`px-3 py-2 rounded-xl border shadow-sm ${editMode? 'bg-[#1A73E8] text-white border-[#1A73E8]':'bg-white'}`}>{editMode? '\uc218\ub3d9 \ud3b8집 \uc885\ub8cc':'\uc218\ub3d9 \ud3b8집(\ub4dc\ub798\uadf8)'}</button>
+                <button onClick={addPlayer} className="px-3 py-2 rounded-xl bg-[#1A73E8] text-white hover:brightness-110">선수 \ucd94가</button>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {players.map((p) => (
+                <PlayerChip key={p.name} name={p.name} />
+              ))}
+            </div>
+            <div className="text-xs text-slate-500">* \uc218\ub3d9 \ud3b8집 \ubaa8드에서 \uc774름 칩을 슬롯에 \ub4dc래그해 \uad50체/\uc2a4왑할 \uc218 \uc788습니다.</div>
+          </div>
+        </section>
+
+        {/* 대진표 */}
+        <section className="bg-white rounded-2xl border border-slate-200 p-4">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="font-semibold">대진표 (한 \ucf54트 = 두 \ud398어)</h2>
+            <div className="text-sm text-slate-500">빈 \uce78은 \ubc30정 \ubd88가(인원/\uc81c약 \uacfc단) → \uc124정 \uc870정 \ud6c4 \uc7ac생성</div>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-slate-50">
+                  <th className="p-2 text-left">게임</th>
+                  <th className="p-2 text-left">코트</th>
+                  <th className="p-2 text-left">일정</th>
+                  <th className="p-2 text-left">경기타입</th>
+                  <th className="p-2 text-left">팀A</th>
+                  <th className="p-2 text-left">팀B</th>
+                  <th className="p-2 text-left">배럴런스</th>
+                </tr>
+              </thead>
+              <tbody>
+                {displaySchedule.map((s, idx) => {
+                  const aSum = s.teamA ? s.teamA.ratingSum?.toFixed(1) : "-";
+                  const bSum = s.teamB ? s.teamB.ratingSum?.toFixed(1) : "-";
+                  const diff = (s.teamA && s.teamB) ? Math.abs((s.teamA.ratingSum||0) - (s.teamB.ratingSum||0)).toFixed(1) : "-";
+                  return (
+                    <tr key={idx} className="border-b hover:bg-slate-50">
+                      <td className="p-2">{idx + 1}</td>
+                      <td className="p-2">{s.courtIndex}</td>
+                      <td className="p-2">{s.timeStr}</td>
+                      <td className="p-2">{s.type}</td>
+                      <td className="p-2 space-x-1">
+                        <DropSlot slotIdx={idx} teamKey="teamA" placeKey="a" name={s.teamA?.a} />
+                        <span className="mx-1">/</span>
+                        <DropSlot slotIdx={idx} teamKey="teamA" placeKey="b" name={s.teamA?.b} />
+                        <span className="text-[11px] text-slate-500 ml-1">= {aSum}</span>
+                      </td>
+                      <td className="p-2 space-x-1">
+                        <DropSlot slotIdx={idx} teamKey="teamB" placeKey="a" name={s.teamB?.a} />
+                        <span className="mx-1">/</span>
+                        <DropSlot slotIdx={idx} teamKey="teamB" placeKey="b" name={s.teamB?.b} />
+                        <span className="text-[11px] text-slate-500 ml-1">= {bSum}</span>
+                      </td>
+                      <td className="p-2">{diff}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* 요약 */}
+        <section className="grid lg:grid-cols-2 gap-4">
+          <div className="bg-white rounded-2xl border border-slate-200 p-4">
+            <h2 className="font-semibold mb-2">출전수 요약</h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {players.map((p) => (
+                <div key={p.name} className="rounded-xl border border-slate-200 px-3 py-2">
+                  <div className="text-sm font-medium">{p.name}</div>
+                  <div className="text-xs text-slate-500">{GENDERS[p.gender]} · NTRP {p.rating?.toFixed(1)}</div>
+                  <div className="text-sm font-semibold">{(gamesPerPlayer[p.name] || 0)} 경기</div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="bg-white rounded-2xl border border-slate-200 p-4">
+            <h2 className="font-semibold mb-2">페어 중복 현황 (상위)</h2>
+            <ul className="space-y-1 max-h-52 overflow-auto pr-2">
+              {Object.entries(pairUsed).sort((a,b)=>b[1]-a[1]).slice(0,12).map(([k,v])=>{
+                const [a,b] = k.split("__");
+                return (
+                  <li key={k} className="text-sm flex justify-between">
+                    <span>{a} - {b}</span>
+                    <span className="text-slate-600">{v}회</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </section>
+
+        <footer className="text-xs text-slate-500 text-center py-6">
+          ⓒ 신나용테니스 · 대진 생성 알고리즘: NTRP 배럴링 + 빠른퇴장 우선 배치 + 하드퇴장옵션 + DnD · v6
+        </footer>
+      </div>
+    </div>
+  );
+}
 


### PR DESCRIPTION
## Summary
- add full single-file React app for tennis pair scheduling
- support drag-and-drop manual edits with gender and leave-time validation
- export current schedule to CSV and include basic self-tests

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aa53198a448322bb42ab9b0e730a33