### PR TITLE
refactor: index-based time iteration

### DIFF
--- a/tennis
+++ b/tennis
@@ -136,7 +136,9 @@ function scheduleMatches({ players, slots, seed, maxGamesPerPlayer, hardLeaveBan
 
   const playersMap = new Map(players.map(p=>[p.name,p]));
 
-  for (const t of timeKeys) {
+  for (let i = 0; i < timeKeys.length; i++) {
+    const t = timeKeys[i];
+    const prevTimeStr = timeKeys[i - 1];
     const timeSlots = byTime[t];
     const usedPlayers = new Set();
     const slotMin = timeStrToMinutes(t) ?? 0;


### PR DESCRIPTION
## Summary
- iterate timeSlots by index in scheduleMatches for efficiency
- derive `prevTimeStr` from loop index instead of indexOf

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5afd3e9c8322a7d299c482c0748c