### PR TITLE
Add PWA manifest and service worker templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,24 @@ SheetJS (xlsx) — XLSX 내보내기용 (CDN 동적 로드)
 
 세션 저장/불러오기 (LocalStorage)
 
-PWA 아이콘/매니페스트 포함 템플릿
+## 📱 PWA 템플릿
+
+- `manifest.webmanifest`: 앱 이름, 아이콘, 테마 색상 등을 정의합니다.
+- `sw.js`: 설치/활성화 이벤트만 처리하는 간단한 서비스 워커 예제입니다.
+
+React/Vite 환경에서는 `index.html`에 다음 링크를 추가하고, `main.tsx`에서 서비스 워커를 등록하세요.
+
+```html
+<link rel="manifest" href="/manifest.webmanifest">
+```
+
+```ts
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js');
+}
+```
+
+Next.js(App Router)에서는 `app/manifest.webmanifest` 파일을 두고 `public` 디렉터리에 `sw.js`를 넣은 뒤 `layout.tsx`에서 `<link rel="manifest" href="/manifest.webmanifest" />`를 추가하면 됩니다.
 
 👨‍💻 개발 메모
 

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "신나용테니스 대진표",
+  "short_name": "신나용",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#FFFFFF",
+  "theme_color": "#1A73E8",
+  "icons": [
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,3 @@
+self.addEventListener('install', e => self.skipWaiting());
+self.addEventListener('activate', e => self.clients.claim());
+self.addEventListener('fetch', () => {});


### PR DESCRIPTION
## Summary
- add `manifest.webmanifest` template for Shin Nayong Tennis app
- include minimal `sw.js` service worker
- document PWA usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa5fa715b0832298b45b7f1aed59b3